### PR TITLE
Specify dependency on CL aliases

### DIFF
--- a/req-package.el
+++ b/req-package.el
@@ -106,6 +106,7 @@
 
 ;;; Code:
 
+(eval-when-compile (require 'cl))
 (require 'use-package)
 (require 'package)
 (require 'dash)


### PR DESCRIPTION
Fixes errors about void functions cadar, caaar, etc. if cl hasn't already been loaded.
