### PR TITLE
Make :load-path keyword work again

### DIFF
--- a/req-package-providers.el
+++ b/req-package-providers.el
@@ -24,6 +24,10 @@
   :group 'req-package
   :type 'list)
 
+
+(defvar req-package-paths (make-hash-table :size 200 :test 'equal)
+  "Package symbol -> custom load path.")
+
 (defun req-package-providers-get-map ()
   "Just get package providers list."
   req-package-providers-map)
@@ -74,12 +78,15 @@
   (unless (package-built-in-p package)
     (error "package is not built-in")))
 
+(defun req-package--load-path (package)
+  (append (ht-get req-package-paths package nil) load-path))
+
 (defun req-package-providers-present-path (package)
-  (if (locate-file (symbol-name package) load-path '(".el" ".elc")) t nil))
+  (locate-file (symbol-name package) (req-package--load-path package) '(".el" ".elc")))
 
 (defun req-package-providers-install-path (package)
-  (unless (locate-file (symbol-name package) load-path '(".el" ".elc"))
-    (error "package is not on load path")))
+  (unless (req-package-providers-present-path package)
+     (error "package is not on load path")))
 
 (defun req-package-providers-prepare (package &optional loader)
   "Prepare PACKAGE - install if it is present using LOADER if specified."


### PR DESCRIPTION
**use-package** has `:load-path` keyword which is used to specify the location of a local package. (basically, it adds specified paths to `load-path` before loading the package). Instead of processing   `:load-path` keyword directly, **req-package** passes its value to **use-package**.

So when I upgraded from **use-package** to **req-package** (having in mind the discussion in #32), I changed

``` elisp
(use-package foo
  :load-path "path/to/foo"
...)
```

to

``` elisp
(req-package foo :loader :built-in
  :load-path "path/to/foo"
...)
```

and that worked like a charm (despite abusing the `:built-in` loader).

However, when 0ae5d45 had been  introduced featuring dedicated `:path`  loader, this setup broke because `req-package-provider-(present|install)-path` functions search for a package without regard to the `:load-path` value.

Possible workaround

``` elisp
(add-to-list 'load-path (expand-file-name "path/to/foo" user-emacs-directory))

...

(req-package foo  :loader :path
...)
```

looks kinda unsightly compared to the previous setup, so I've written a patch to make  `req-package-provider-(present|install)-path` search for packages using the `:load-path` value  (if specified) in addition to the global load path.
