### PR TITLE
Add el-get dependency to Package-Requires header

### DIFF
--- a/req-package.el
+++ b/req-package.el
@@ -5,7 +5,7 @@
 ;; Author: Edward Knyshov <edvorg@gmail.com>
 ;; Created: 25 Dec 2013
 ;; Version: 1.2
-;; Package-Requires: ((use-package "1.0") (dash "2.7.0") (log4e "0.2.0") (ht "0"))
+;; Package-Requires: ((use-package "1.0") (dash "2.7.0") (log4e "0.2.0") (ht "0") (el-get "5.1"))
 ;; Keywords: dotemacs startup speed config package
 ;; X-URL: https://github.com/edvorg/req-package
 


### PR DESCRIPTION
Since el-get 5.1 (the latest) was released in 2014, it's probably a reasonable minimum version. `el-get` releases: https://github.com/dimitri/el-get/releases

See also: https://github.com/melpa/melpa/issues/5341

Thanks for the package!